### PR TITLE
Feed: Replaced the deprecated getRoleCategory() method

### DIFF
--- a/Feed/CHANGEDB.php
+++ b/Feed/CHANGEDB.php
@@ -74,3 +74,8 @@ $sql[$count][1] = "";
 ++$count;
 $sql[$count][0] = '1.2.02';
 $sql[$count][1] = "";
+
+//v1.3.00
+++$count;
+$sql[$count][0] = '1.3.00';
+$sql[$count][1] = "";

--- a/Feed/CHANGELOG.txt
+++ b/Feed/CHANGELOG.txt
@@ -1,5 +1,9 @@
 CHANGELOG
 =========
+v1.3.00
+-------
+Replaced the deprecated getRoleCategory() method
+
 v1.2.02
 -------
 Fixed JS bug introduced in ownership transfer

--- a/Feed/feed_view_ajax.php
+++ b/Feed/feed_view_ajax.php
@@ -19,7 +19,6 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
-use Gibbon\Domain\User\RoleGateway;
 use Gibbon\Services\Format;
 
 //Gibbon system-wide includes
@@ -30,7 +29,7 @@ require_once './src/Library/RollingCurl/RollingCurl.php';
 require_once './src/Library/RollingCurl/Request.php';
 
 $output = '';
-$category = $container->get(RoleGateway::class)->getRoleCategory($session->get('gibbonRoleIDCurrent'));
+$category = $session->get('gibbonRoleIDCurrentCategory');
 $gibbonPersonID = $_GET['gibbonPersonID'] ?? null;
 
 if (is_null($gibbonPersonID) or $gibbonPersonID=='') {

--- a/Feed/feed_view_ajax.php
+++ b/Feed/feed_view_ajax.php
@@ -19,6 +19,7 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
+use Gibbon\Domain\User\RoleGateway;
 use Gibbon\Services\Format;
 
 //Gibbon system-wide includes
@@ -29,9 +30,7 @@ require_once './src/Library/RollingCurl/RollingCurl.php';
 require_once './src/Library/RollingCurl/Request.php';
 
 $output = '';
-
-$category = getRoleCategory($session->get('gibbonRoleIDCurrent'), $connection2);
-
+$category = $container->get(RoleGateway::class)->getRoleCategory($session->get('gibbonRoleIDCurrent'));
 $gibbonPersonID = $_GET['gibbonPersonID'] ?? null;
 
 if (is_null($gibbonPersonID) or $gibbonPersonID=='') {

--- a/Feed/hook_dashboard_feedView.php
+++ b/Feed/hook_dashboard_feedView.php
@@ -22,19 +22,10 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 $returnInt = null;
 
 //Only include module include if it is not already included (which it may be been on the index page)
-$included = false;
-$includes = get_included_files();
-foreach ($includes as $include) {
-    if ($include == $session->get('absolutePath').'/modules/Feed/moduleFunctions.php') {
-        $included = true;
-    }
-}
-if ($included == false) {
-    include './modules/Feed/moduleFunctions.php';
-}
+require_once $session->get('absolutePath').'/modules/Feed/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Feed/feed_view.php') == false) {
-    //Acess denied
+    // Access denied
     $returnInt .= "<div class='error'>";
     $returnInt .= 'You do not have access to this action.';
     $returnInt .= '</div>';

--- a/Feed/manifest.php
+++ b/Feed/manifest.php
@@ -27,7 +27,7 @@ $description = 'Offers a unified feed of latest posts from student and class web
 $entryURL = 'feed_view.php';
 $type = 'Additional';
 $category = 'Other';
-$version = '1.2.02';
+$version = '1.3.00';
 $author = "Gibbon Foundation";
 $url = "https://gibbonedu.org";
 

--- a/Feed/moduleFunctions.php
+++ b/Feed/moduleFunctions.php
@@ -19,16 +19,13 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-use Gibbon\Domain\User\RoleGateway;
-
 function getFeed($connection2, $guid, $gibbonPersonID)
 {
-    global $session, $container;
+    global $session;
     
     $output = '';
     
-    $category = $container->get(RoleGateway::class)->getRoleCategory($session->get('gibbonRoleIDCurrent'));
-    
+    $category = $session->get('gibbonRoleIDCurrentCategory');
     $output .= '<p>';
         if ($category == "Staff") {
             $output .= __('Shown below is a list of the most recent 20 posts, drawn from your own website, and that of class and student websites for your form groups.') ;

--- a/Feed/moduleFunctions.php
+++ b/Feed/moduleFunctions.php
@@ -19,13 +19,16 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+use Gibbon\Domain\User\RoleGateway;
+
 function getFeed($connection2, $guid, $gibbonPersonID)
 {
-    global $session;
+    global $session, $container;
     
     $output = '';
-
-    $category = getRoleCategory($session->get('gibbonRoleIDCurrent'), $connection2);
+    
+    $category = $container->get(RoleGateway::class)->getRoleCategory($session->get('gibbonRoleIDCurrent'));
+    
     $output .= '<p>';
         if ($category == "Staff") {
             $output .= __('Shown below is a list of the most recent 20 posts, drawn from your own website, and that of class and student websites for your form groups.') ;

--- a/Feed/version.php
+++ b/Feed/version.php
@@ -22,5 +22,5 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 /**
  * Sets version information.
  */
-$moduleVersion = '1.2.02';
+$moduleVersion = '1.3.00';
 $coreVersion = '22.0.00';


### PR DESCRIPTION
Replaced the deprecated getRoleCategory() method and use the RoleGateway class.